### PR TITLE
Add travis ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: clojure
+lein: lein2
+before_install: cd stefon-core
+script: lein2 test
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7


### PR DESCRIPTION
Runs lein test in stefon-core using travis.

See the successful build here: https://travis-ci.org/RyanMcG/stefon/jobs/14087165.

Of course, just including this file alone would not get travis-ci working in the circleci repo. You would need to do a bit of configuration on the travis side.  At that point we could add a build status image to the README too.
