### PR TITLE
Make options passed into asset-pipeline optional.

### DIFF
--- a/stefon-core/src/stefon/core.clj
+++ b/stefon-core/src/stefon/core.clj
@@ -49,7 +49,7 @@ ex. (link-to-asset \"javascripts/app.js\") => \"/assets/javascripts/app-12345678
    either loading the data from the cache directory, rendering a new resource and
    returning that, or passing on the request to the previously existing request
    handlers in the pipeline."
-  [app options]
+  [app & [options]]
   (settings/with-options options
     (-> (settings/serving-asset-root) io/file .mkdirs)
     (-> app


### PR DESCRIPTION
Was part of #3. I suspect this is my most controversial change. Honestly, it is the one I find least valuable although my usecase supports it (defaults are sufficient). Requiring options to be passed in is restricting while providing instructions that the typical use case is to do so is ideal.
